### PR TITLE
Fix typo in download link in docs for MacOS

### DIFF
--- a/install.mec
+++ b/install.mec
@@ -8,7 +8,7 @@ You can download the latest release (v0.0.4-alpha) from our GitHub repository.
 
 - Linux - <a href="https://github.com/mech-lang/mech/releases/download/v0.0.4/mech_0.0.4_linux_x86_64.7z">binary (2.52 MB)</a>
 - Windows - <a href="https://github.com/mech-lang/mech/releases/download/v0.0.4/mech_0.0.4_windows_x86_64.7z">binary (1.57 MB)</a>
-- MacOS - <a href="https://github.com/mech-lang/mech/releases/download/v0.0.4/mech_0.0.4_windows_x86_64.7z">binary (1.74 MB)</a>
+- MacOS - <a href="https://github.com/mech-lang/mech/releases/download/v0.0.4/mech_0.0.4_macos_x86_64.7z">binary (1.74 MB)</a>
 
 ## Build From Source
 


### PR DESCRIPTION
:) It was previously downloading the windows binary. (I saw your talk at HYTRADOI and wanted to check it out!) :)